### PR TITLE
chore: sync release v0.5.2 from masa-codehub/dev_issue_creator_kit

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo \
     tar \
     zlib1g-dev \
-    rsync \
     && rm -rf /var/lib/apt/lists/*
 
 # 3. GitHub CLI のインストール (wgetを使わずcurlで実行)


### PR DESCRIPTION
Automated synchronization of release v0.5.2 from the development repository (masa-codehub/dev_issue_creator_kit).